### PR TITLE
Fix for deployment failure caused by lambda name too long

### DIFF
--- a/template.yml
+++ b/template.yml
@@ -7,35 +7,35 @@ Resources:
       Properties:
         CodeUri: src/handler/
         Handler: get.handler
-        Runtime: nodejs12.x  
+        Runtime: nodejs12.x
         Events:
           GetLambdaApi:
             Type: Api
             Properties:
               Path: /
               Method: get
-    
+
     PostLambdaFunction:
       Type: 'AWS::Serverless::Function'
       Properties:
         CodeUri: src/handler/
         Handler: post.handler
-        Runtime: nodejs12.x  
+        Runtime: nodejs12.x
         Events:
           PostLambdaApi:
             Type: Api
             Properties:
               Path: /
               Method: post
-    
-    CloudWatchEventLambdaFunction:
+
+    CWEventLambdaFunction:
       Type: 'AWS::Serverless::Function'
       Properties:
         CodeUri: src/handler/
         Handler: cloudWatchEvent.handler
-        Runtime: nodejs12.x  
+        Runtime: nodejs12.x
         Events:
-          CloudWatchEventLambdaSchedule:
+          CWEventLambdaSchedule:
             Type: Schedule
             Properties:
               Schedule: 'rate(1 minute)'
@@ -55,10 +55,10 @@ Outputs:
   PostLambdaFunction:
     Description: "Post Lambda Function ARN"
     Value: !GetAtt PostLambdaFunction.Arn
-  
-  CloudWatchEventLambdaSchedule:
+
+  CWEventLambdaSchedule:
     Description: "CloudWatch Event schedule for CloudWatchEventLambdaFunction"
     Value: "rate(1 minute)"
-  CloudWatchEventLambdaFunction:
+  CWEventLambdaFunction:
     Description: "CloudWatch Event Lambda Function ARN"
-    Value: !GetAtt CloudWatchEventLambdaFunction.Arn
+    Value: !GetAtt CWEventLambdaFunction.Arn


### PR DESCRIPTION
## Description

This is a change that I'm proposing after noticing that the example `CloudWatchEventLambdaFunction` caused a deployment failure because its name was too long.

Of course this is an issue only if one tries to deploy the starter project as is, but I thought it would save time to those who experiment with the starter project as I did.

Related issue: *none*


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works