### PR TITLE
Correctly generate correlationId when lambda is invoked without headers

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -27,7 +27,7 @@ export class Logger {
 export const createLogger = (event: APIGatewayProxyEvent, context: Context): Logger => {
   const lambdaRequestId: string = context.awsRequestId;
   const apiRequestId: string = event?.requestContext.requestId;
-  const correlationId: string = event?.headers['X-Correlation-Id'] || lambdaRequestId;
+  const correlationId: string = event?.headers?.['X-Correlation-Id'] || lambdaRequestId;
 
   return new Logger(apiRequestId, correlationId);
 };

--- a/tests/util/logger.test.ts
+++ b/tests/util/logger.test.ts
@@ -35,6 +35,25 @@ describe('Test logger', () => {
     );
   });
 
+  test('createLogger() should set the correlationId to awsRequestId when invoked without an X-Correlation-Id header',
+    () => {
+      const queryStringParameters: Record<string, string> = {};
+      const apiRequestId: string = v4();
+      const requestContext: APIGatewayEventRequestContext = <APIGatewayEventRequestContext> { requestId: apiRequestId };
+      const headers: Record<string, string> = {}; // no headers
+      const eventMock: APIGatewayProxyEvent = <APIGatewayProxyEvent> { queryStringParameters, requestContext, headers };
+      const awsRequestId: string = v4();
+      const contextMock: Context = <Context> { awsRequestId };
+
+      const logger: Logger = createLogger(eventMock, contextMock);
+
+      expect(logger.logFormat).toBe(JSON.stringify({
+        apiRequestId,
+        correlationId: awsRequestId,
+        message: '%s',
+      }));
+    });
+
   test('logger.debug() calls console.debug() with expected parameters', () => {
     const logger: Logger = new Logger('', '');
     console.debug = jest.fn();


### PR DESCRIPTION
## Description

I'm proposing this tiny change after deploying the project to my personal AWS account.

I noticed that when testing lambdas from within the AWS console, by default no HTTP headers are sent (of course it is possible to send them with a bit of fiddling in the UI, though). This will make the lambda go 500 Internal Error.

This simple code change will make the logger correctly fall back to the AWS request ID if no headers are sent.

Not a massive issue, and very unlikely to happen in the real world, but I thought it could be useful.

Related issue: *none*


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works