### PR TITLE
New templates for Feature Requests & Bug Reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yaml
@@ -1,0 +1,31 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yaml
@@ -1,0 +1,32 @@
+name: Feature Request 
+description: Request a new feature and enhancement
+title: "[Feature Request]: "
+labels: ["feature"] 
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: feature-request
+    attributes:
+      label: Feature Request
+      description: What would you like to see implemented?
+      placeholder: Please provide as much information and background as you can
+    validations:
+      required: true
+  - type: textarea
+    id: alternative-information
+    attributes:
+      label: Are you currently using a workaround / alternative solution instead?
+      placeholder: Please provide as much information and background as you can
+    validations:
+      required: true


### PR DESCRIPTION
## Description

- Added templates for raising issues on GitHub
- If issues and bugs are raised consistently, it helps
keep the project organised and easy to find information
- Link to GitHub documentation [here](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository).

Related issue: n/a

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works