### PR TITLE
Add EditorConfig support for consistent IDE styling

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["dbaeumer.vscode-eslint", "EditorConfig.EditorConfig"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,14 @@
-{    
+{
+  "files.associations": {
+    ".eslintrc": "jsonc",
+  },
+
+  "javascript.validate.enable": false,
+  "javascript.format.enable": false,
+  "typescript.format.enable": false,
+
   "eslint.enable": true,
-  "eslint.options": { "configFile": ".eslintrc" },
-  "editor.detectIndentation": false,
-  "editor.tabSize": 2,
+
   "editor.rulers": [120],
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   "editor.formatOnSave": false,


### PR DESCRIPTION
## Description

Add [EditorConfig](https://editorconfig.org/#overview) for consistent styling across IDEs (decoupling from VSCode).

Also adds config so that VSCode will recommend ESLint + EditorConfig extensions in VSCode (to be a better transition). JetBeans has `EditorConfig` natively included in most flavours.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works