### PR TITLE
Update ESLint rules to be okay with dev dependencies

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,5 +8,13 @@
         "alwaysTryTypes": true
       }
     }
+  },
+  "rules": {
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   }
 }


### PR DESCRIPTION
## Description

As this repo is always built using Webpack, all dependencies should, in my opinion, be in `devDependencies`. This tells ESLint that it's fine to import `devDependencies` in the `src/` code.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works