### PR TITLE
Update Snyk command to `test` in CI

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,15 +1,17 @@
 name: Synk Security run
+
 on: push
+
 jobs:
   security:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/node@master
-        continue-on-error: false 
+        continue-on-error: false
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           json: true
-          command: monitor
+          command: test


### PR DESCRIPTION
## Description

Snyk `monitor` command is async and will not fail on the CI. This PR changes the command to `test` which is more appropriate for CI (https://support.snyk.io/hc/en-us/articles/360002847677-Can-snyk-monitor-send-a-fail-code-like-snyk-test-or-do-you-need-to-run-both-to-save-results-and-fail-a-test-).


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works