### PR TITLE
Adds `npm run build:prod` to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,3 +20,5 @@ jobs:
         run: npm run lint:ci
       - name: Run tests
         run: npm run test:ci
+      - name: Build
+        run: npm run build:prod


### PR DESCRIPTION
## Description

Adds a build step to the CI to ensure that the Lambdas compile. The build artefacts can then be potentially used to push to the cloud (S3).

Closes #55 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works