### PR TITLE
Turn on TypeScript strict mode

### DIFF
--- a/src/handler/cloudWatchEvent.ts
+++ b/src/handler/cloudWatchEvent.ts
@@ -1,19 +1,13 @@
 import 'dotenv/config';
-import type { Context, ScheduledEvent } from 'aws-lambda';
+import type { ScheduledEvent } from 'aws-lambda';
 import logger from '../util/logger';
 
-/**
- * Lambda Handler
- *
- * @param {ScheduledEvent} event
- * @param {Context} context
- * @returns {Promise<Record<string, unknown>>}
- */
-export const handler = async (event: ScheduledEvent, context: Context): Promise<Record<string, unknown>> => {
+// eslint-disable-next-line @typescript-eslint/require-await
+export const handler = async (event: ScheduledEvent): Promise<Record<string, number|string>> => {
   logger.info('Cloudwatch event successfully triggered!');
 
-  return Promise.resolve({
+  return {
     statusCode: 200,
-    body: 'Cloudwatch event successfully triggered!',
-  });
+    body: `Cloudwatch event ${event.id} successfully triggered!`,
+  };
 };

--- a/src/handler/cloudWatchEvent.ts
+++ b/src/handler/cloudWatchEvent.ts
@@ -3,7 +3,7 @@ import type { ScheduledEvent } from 'aws-lambda';
 import logger from '../util/logger';
 
 // eslint-disable-next-line @typescript-eslint/require-await
-export const handler = async (event: ScheduledEvent): Promise<Record<string, number|string>> => {
+export const handler = async (event: ScheduledEvent): Promise<Record<string, number | string>> => {
   logger.info('Cloudwatch event successfully triggered!');
 
   return {

--- a/src/handler/get.ts
+++ b/src/handler/get.ts
@@ -1,21 +1,24 @@
 import 'dotenv/config';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import logger from '../util/logger';
 
-/**
- * Lambda Handler
- *
- * @param {APIGatewayProxyEvent} event
- * @param {Context} context
- * @returns {Promise<APIGatewayProxyResult>}
- */
-export const handler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
-  const queryParams: Record<string, string> = event.queryStringParameters;
+// eslint-disable-next-line @typescript-eslint/require-await
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  if (!event.queryStringParameters) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: 'Missing query string parameters',
+      }),
+    };
+  }
+
+  const queryParams = event.queryStringParameters;
 
   logger.info(queryParams);
 
-  return Promise.resolve({
+  return {
     statusCode: 200,
     body: JSON.stringify({ queryParams }),
-  });
+  };
 };

--- a/src/handler/post.ts
+++ b/src/handler/post.ts
@@ -1,21 +1,24 @@
 import 'dotenv/config';
-import type { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+import type { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import logger from '../util/logger';
 
-/**
- * Lambda Handler
- *
- * @param {APIGatewayProxyEvent} event
- * @param {Context} context
- * @returns {Promise<APIGatewayProxyResult>}
- */
-export const handler = async (event: APIGatewayProxyEvent, context: Context): Promise<APIGatewayProxyResult> => {
-  const body: Record<string, unknown> = <Record<string, unknown>> JSON.parse(event.body);
+// eslint-disable-next-line @typescript-eslint/require-await
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  if (!event.body) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: 'Missing body',
+      }),
+    };
+  }
+
+  const body = JSON.parse(event.body) as unknown;
 
   logger.info(body);
 
-  return Promise.resolve({
+  return {
     statusCode: 201,
     body: JSON.stringify({ body }),
-  });
+  };
 };

--- a/tests/handler/cloudWatchEvent.test.ts
+++ b/tests/handler/cloudWatchEvent.test.ts
@@ -1,4 +1,4 @@
-import type { Context, ScheduledEvent } from 'aws-lambda';
+import type { ScheduledEvent } from 'aws-lambda';
 import { v4 } from 'uuid';
 import { handler } from '../../src/handler/cloudWatchEvent';
 
@@ -6,10 +6,9 @@ jest.mock('../../src/util/logger.ts');
 
 describe('Test CloudWatch Event Lambda Function', () => {
   test('should return 200 with a success message', async () => {
-    const eventMock: ScheduledEvent = <ScheduledEvent> { };
-    const contextMock: Context = <Context> { awsRequestId: v4() };
+    const eventMock: ScheduledEvent = <ScheduledEvent> { id: v4() };
 
-    const res: Record<string, unknown> = await handler(eventMock, contextMock);
+    const res: Record<string, string|number> = await handler(eventMock);
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual('Cloudwatch event successfully triggered!');

--- a/tests/handler/cloudWatchEvent.test.ts
+++ b/tests/handler/cloudWatchEvent.test.ts
@@ -8,7 +8,7 @@ describe('Test CloudWatch Event Lambda Function', () => {
   test('should return 200 with a success message', async () => {
     const eventMock: ScheduledEvent = <ScheduledEvent> { id: v4() };
 
-    const res: Record<string, string|number> = await handler(eventMock);
+    const res: Record<string, string | number> = await handler(eventMock);
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual('Cloudwatch event successfully triggered!');

--- a/tests/handler/cloudWatchEvent.test.ts
+++ b/tests/handler/cloudWatchEvent.test.ts
@@ -6,11 +6,12 @@ jest.mock('../../src/util/logger.ts');
 
 describe('Test CloudWatch Event Lambda Function', () => {
   test('should return 200 with a success message', async () => {
-    const eventMock: ScheduledEvent = <ScheduledEvent> { id: v4() };
+    const id = v4();
+    const eventMock: ScheduledEvent = <ScheduledEvent> { id };
 
     const res: Record<string, string | number> = await handler(eventMock);
 
     expect(res.statusCode).toBe(200);
-    expect(res.body).toEqual('Cloudwatch event successfully triggered!');
+    expect(res.body).toEqual(`Cloudwatch event ${id} successfully triggered!`);
   });
 });

--- a/tests/handler/get.test.ts
+++ b/tests/handler/get.test.ts
@@ -1,5 +1,5 @@
 import type {
-  APIGatewayProxyEvent, APIGatewayProxyResult, Context, APIGatewayEventRequestContext,
+  APIGatewayProxyEvent, APIGatewayProxyResult, APIGatewayEventRequestContext,
 } from 'aws-lambda';
 import { v4 } from 'uuid';
 import { handler } from '../../src/handler/get';
@@ -16,9 +16,8 @@ describe('Test Get Lambda Function', () => {
       requestContext,
       headers,
     };
-    const contextMock: Context = <Context> { awsRequestId: v4() };
 
-    const res: APIGatewayProxyResult = await handler(eventMock, contextMock);
+    const res: APIGatewayProxyResult = await handler(eventMock);
 
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual(JSON.stringify({ queryParams: queryStringParameters }));

--- a/tests/handler/post.test.ts
+++ b/tests/handler/post.test.ts
@@ -1,5 +1,5 @@
 import type {
-  APIGatewayProxyEvent, APIGatewayProxyResult, Context, APIGatewayEventRequestContext,
+  APIGatewayProxyEvent, APIGatewayProxyResult, APIGatewayEventRequestContext,
 } from 'aws-lambda';
 import { v4 } from 'uuid';
 import { handler } from '../../src/handler/post';
@@ -16,9 +16,8 @@ describe('Test Post Lambda Function', () => {
       requestContext,
       headers,
     };
-    const contextMock: Context = <Context> { awsRequestId: v4() };
 
-    const res: APIGatewayProxyResult = await handler(eventMock, contextMock);
+    const res: APIGatewayProxyResult = await handler(eventMock);
 
     expect(res.statusCode).toBe(201);
     expect(res.body).toEqual(JSON.stringify({ body }));

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "allowJs": true,
     "checkJs": true,
     "sourceMap": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true
   },
   "include": ["src/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Description
Enables TypeScript strict mode by default - https://www.typescriptlang.org/tsconfig#strict.

I'm unsure how to handle the lack of await without filling the handlers with some example async commands. Instead, I've ignored the ESLint error. The reasoning behind this is that Lambdas will typically _have_ asynchronous commands the majority of the time.
```ts
// eslint-disable-next-line @typescript-eslint/require-await
```

**Value is nicely summed up by TypeScript:**
> The strict flag enables a wide range of type checking behavior that results in stronger guarantees of program correctness.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works